### PR TITLE
Sharding feature: simple solution

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+}
+
+group 'com.jinyframework'
+version '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+def nettyVersion = '4.1.65.Final'
+dependencies {
+    compile project(':store')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+
+    compile group: 'io.netty', name: 'netty-handler', version: "${nettyVersion}"
+    compile group: 'io.netty', name: 'netty-buffer', version: "${nettyVersion}"
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/common/src/main/java/command/CommandHandler.java
+++ b/common/src/main/java/command/CommandHandler.java
@@ -1,0 +1,8 @@
+package command;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface CommandHandler {
+	Object handle(List<String> args);
+}

--- a/common/src/main/java/command/CommandHandler.java
+++ b/common/src/main/java/command/CommandHandler.java
@@ -1,8 +1,0 @@
-package command;
-
-import java.util.List;
-
-@FunctionalInterface
-public interface CommandHandler {
-	Object handle(List<String> args);
-}

--- a/common/src/main/java/config/config/CliProp.java
+++ b/common/src/main/java/config/config/CliProp.java
@@ -1,0 +1,16 @@
+package config.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface CliProp {
+    String name();
+
+    CliPropType type();
+
+    String value() default "";
+}

--- a/common/src/main/java/config/config/CliPropType.java
+++ b/common/src/main/java/config/config/CliPropType.java
@@ -1,0 +1,6 @@
+package config.config;
+
+public enum CliPropType {
+    FLAG,
+    VAL
+}

--- a/common/src/main/java/config/config/ConfigProp.java
+++ b/common/src/main/java/config/config/ConfigProp.java
@@ -1,0 +1,14 @@
+package config.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ConfigProp {
+    String name();
+
+    String defaultVal();
+}

--- a/common/src/main/java/connection/ClientInfo.java
+++ b/common/src/main/java/connection/ClientInfo.java
@@ -1,0 +1,12 @@
+package connection;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class ClientInfo {
+	private final String id;
+}

--- a/common/src/main/java/connection/ConnectionService.java
+++ b/common/src/main/java/connection/ConnectionService.java
@@ -1,0 +1,9 @@
+package connection;
+
+import java.util.concurrent.ConcurrentMap;
+
+public interface ConnectionService {
+	long getCurrentConnectedClients();
+
+	ConcurrentMap<String, ClientInfo> getClients();
+}

--- a/common/src/main/java/connection/ConnectionServiceDefaultImpl.java
+++ b/common/src/main/java/connection/ConnectionServiceDefaultImpl.java
@@ -1,0 +1,18 @@
+package connection;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class ConnectionServiceDefaultImpl implements ConnectionService {
+	private final ConcurrentHashMap<String, ClientInfo> clients = new ConcurrentHashMap<>();
+
+	@Override
+	public long getCurrentConnectedClients() {
+		return clients.size();
+	}
+
+	@Override
+	public ConcurrentMap<String, ClientInfo> getClients() {
+		return clients;
+	}
+}

--- a/common/src/main/java/server/IServer.java
+++ b/common/src/main/java/server/IServer.java
@@ -1,0 +1,5 @@
+package server;
+
+public interface IServer extends Runnable {
+    void shutdown();
+}

--- a/common/src/main/java/storage/NoHeapStorageServiceImpl.java
+++ b/common/src/main/java/storage/NoHeapStorageServiceImpl.java
@@ -1,0 +1,35 @@
+package storage;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.jinyframework.keva.store.NoHeapStore;
+
+public class NoHeapStorageServiceImpl implements StorageService {
+	private static NoHeapStore store;
+
+	@Override
+	public void setStore(NoHeapStore store) {
+		NoHeapStorageServiceImpl.store = store;
+	}
+
+	@Override
+	public Path getSnapshotPath() {
+		return Paths.get(store.getFolder());
+	}
+
+	@Override
+	public boolean putString(String key, String val) {
+		return store.putString(key,val);
+	}
+
+	@Override
+	public String getString(String key) {
+		return store.getString(key);
+	}
+
+	@Override
+	public boolean remove(String key) {
+		return store.remove(key);
+	}
+}

--- a/common/src/main/java/storage/StorageService.java
+++ b/common/src/main/java/storage/StorageService.java
@@ -1,0 +1,19 @@
+package storage;
+
+import java.nio.file.Path;
+
+import com.jinyframework.keva.store.NoHeapStore;
+
+public interface StorageService {
+	// setter dep injection
+	void setStore(NoHeapStore store);
+
+	Path getSnapshotPath();
+
+	boolean putString(String key, String val);
+
+	String getString(String key);
+
+	boolean remove(String key);
+}
+

--- a/common/src/main/java/util/ArgsHolder.java
+++ b/common/src/main/java/util/ArgsHolder.java
@@ -1,0 +1,38 @@
+package util;
+
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@ToString
+public class ArgsHolder {
+    private final Map<String, String> values = new HashMap<>();
+    private final Set<String> flags = new HashSet<>();
+
+    public void addFlag(String name) {
+        flags.add(name);
+    }
+
+    @SuppressWarnings("ReturnOfNull")
+    public String getFlag(String name) {
+        if (flags.contains(name)) {
+            return "true";
+        }
+        return null;
+    }
+
+    public void addArgVal(String name, String value) {
+        values.put(name, value);
+    }
+
+    @SuppressWarnings("ReturnOfNull")
+    public String getArgVal(String name) {
+        if (values.containsKey(name)) {
+            return values.get(name);
+        }
+        return null;
+    }
+}

--- a/common/src/main/java/util/ArgsParser.java
+++ b/common/src/main/java/util/ArgsParser.java
@@ -1,0 +1,26 @@
+package util;
+
+import lombok.val;
+
+public final class ArgsParser {
+    private ArgsParser() {
+    }
+
+    public static ArgsHolder parse(String[] args) {
+        val holder = new ArgsHolder();
+        for (int i = 0; i < args.length; i++) {
+            val token = args[i];
+            if (token.startsWith("-")) {
+                val name = token.substring(1);
+                if (i >= args.length - 1) {
+                    holder.addFlag(name);
+                } else if (args[i + 1].startsWith("-")) {
+                    holder.addFlag(name);
+                } else if (!args[i + 1].isEmpty()) {
+                    holder.addArgVal(name, args[i + 1]);
+                }
+            }
+        }
+        return holder;
+    }
+}

--- a/common/src/main/java/util/PortUtil.java
+++ b/common/src/main/java/util/PortUtil.java
@@ -1,0 +1,20 @@
+package util;
+
+import lombok.SneakyThrows;
+import lombok.val;
+
+import java.net.ServerSocket;
+
+public final class PortUtil {
+    private PortUtil() {
+    }
+
+    @SneakyThrows
+    public static int getAvailablePort() {
+        final int port;
+        try (val serverSocket = new ServerSocket(0)) {
+            port = serverSocket.getLocalPort();
+        }
+        return port;
+    }
+}

--- a/common/src/main/java/util/SocketClient.java
+++ b/common/src/main/java/util/SocketClient.java
@@ -1,0 +1,41 @@
+package util;
+
+import lombok.SneakyThrows;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+public class SocketClient {
+    private final String host;
+    private final int port;
+    private Socket socket;
+    private BufferedReader socketIn;
+    private PrintWriter socketOut;
+
+    public SocketClient(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public void connect() throws IOException {
+        socket = new Socket(host, port);
+        socketIn = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+        socketOut = new PrintWriter(socket.getOutputStream());
+    }
+
+    public String exchange(String mess) throws IOException {
+        socketOut.println(mess);
+        socketOut.flush();
+        return socketIn.readLine();
+    }
+
+    @SneakyThrows
+    public void disconnect() {
+        socketIn.close();
+        socketOut.close();
+        socket.close();
+    }
+}

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'application'
+    id 'com.github.johnrengelman.shadow' version '6.0.0'
+    id 'com.adarshr.test-logger' version '2.1.0'
+}
+
+group 'com.jinyframework'
+version '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+def nettyVersion = '4.1.65.Final'
+dependencies {
+    compile project(':store')
+    compile project(':server')
+
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.0.9'
+    compile group: 'ch.qos.logback', name: 'logback-core', version: '1.0.9'
+    compile group: 'io.netty', name: 'netty-handler', version: "${nettyVersion}"
+    compile group: 'io.netty', name: 'netty-buffer', version: "${nettyVersion}"
+}
+
+shadowJar {
+    minimize()
+}
+
+application {
+    mainClassName = 'com.jinyframework.keva.proxy.Application'
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+        outputs.upToDateWhen { false }
+        showStandardStreams = true
+    }
+}

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -14,8 +14,9 @@ repositories {
 def nettyVersion = '4.1.65.Final'
 dependencies {
     compile project(':store')
-    compile project(':server')
+    compile project(':common')
 
+    testCompile project(':server')
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.0.9'
     compile group: 'ch.qos.logback', name: 'logback-core', version: '1.0.9'
     compile group: 'io.netty', name: 'netty-handler', version: "${nettyVersion}"

--- a/proxy/proxy.properties
+++ b/proxy/proxy.properties
@@ -1,0 +1,4 @@
+# Default Keva configuration
+hostname = localhost
+port = 6767
+virtual_node_amount = 3

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/Application.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/Application.java
@@ -1,0 +1,32 @@
+package com.jinyframework.keva.proxy;
+
+import com.jinyframework.keva.proxy.config.ConfigHolder;
+import com.jinyframework.keva.proxy.config.ConfigManager;
+import com.jinyframework.keva.proxy.core.NettyServer;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+@Slf4j
+public final class Application {
+    public static void main(String[] args) {
+        try {
+            final ConfigHolder configHolder = ConfigManager.loadConfig(args);
+            log.info(configHolder.toString());
+
+            val server = new NettyServer(configHolder);
+
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    server.shutdown();
+                } catch (Exception e) {
+                    log.error("Problem occurred when stopping server: ", e);
+                } finally {
+                    log.info("Bye");
+                }
+            }));
+            server.run();
+        } catch (Exception e) {
+            log.error("There was a problem running server: ", e);
+        }
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/ServiceInstance.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/ServiceInstance.java
@@ -1,0 +1,49 @@
+package com.jinyframework.keva.proxy;
+
+import com.jinyframework.keva.proxy.balance.LoadBalancingService;
+import com.jinyframework.keva.proxy.balance.LoadBalancingServiceImpl;
+import com.jinyframework.keva.proxy.command.CommandService;
+import com.jinyframework.keva.proxy.command.CommandServiceImpl;
+import com.jinyframework.keva.server.core.ConnectionService;
+import com.jinyframework.keva.server.core.ConnectionServiceImpl;
+import com.jinyframework.keva.server.storage.NoHeapStorageServiceImpl;
+import com.jinyframework.keva.server.storage.StorageService;
+import lombok.Setter;
+
+@Setter
+public final class ServiceInstance {
+    private ServiceInstance() {
+    }
+
+    public static ConnectionService getConnectionService() {
+        return ConnectionServiceHolder.INSTANCE;
+    }
+
+    public static CommandService getCommandService() {
+        return CommandServiceHolder.INSTANCE;
+    }
+
+    public static StorageService getStorageService() {
+        return StorageServiceHolder.INSTANCE;
+    }
+
+    public static LoadBalancingService getLoadBalancingService() {
+        return LoadBalancingServiceHolder.INSTANCE;
+    }
+
+    private static final class ConnectionServiceHolder {
+        private static final ConnectionService INSTANCE = new ConnectionServiceImpl();
+    }
+
+    private static final class CommandServiceHolder {
+        private static final CommandService INSTANCE = new CommandServiceImpl();
+    }
+
+    private static final class StorageServiceHolder {
+        private static final StorageService INSTANCE = new NoHeapStorageServiceImpl();
+    }
+
+    private static final class LoadBalancingServiceHolder {
+        private static final LoadBalancingService INSTANCE = new LoadBalancingServiceImpl();
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/ServiceInstance.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/ServiceInstance.java
@@ -4,11 +4,11 @@ import com.jinyframework.keva.proxy.balance.LoadBalancingService;
 import com.jinyframework.keva.proxy.balance.LoadBalancingServiceImpl;
 import com.jinyframework.keva.proxy.command.CommandService;
 import com.jinyframework.keva.proxy.command.CommandServiceImpl;
-import com.jinyframework.keva.server.core.ConnectionService;
-import com.jinyframework.keva.server.core.ConnectionServiceImpl;
-import com.jinyframework.keva.server.storage.NoHeapStorageServiceImpl;
-import com.jinyframework.keva.server.storage.StorageService;
+import connection.ConnectionService;
+import connection.ConnectionServiceDefaultImpl;
 import lombok.Setter;
+import storage.NoHeapStorageServiceImpl;
+import storage.StorageService;
 
 @Setter
 public final class ServiceInstance {
@@ -32,7 +32,7 @@ public final class ServiceInstance {
     }
 
     private static final class ConnectionServiceHolder {
-        private static final ConnectionService INSTANCE = new ConnectionServiceImpl();
+        private static final ConnectionService INSTANCE = new ConnectionServiceDefaultImpl();
     }
 
     private static final class CommandServiceHolder {

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingService.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingService.java
@@ -3,5 +3,5 @@ package com.jinyframework.keva.proxy.balance;
 public interface LoadBalancingService {
 	void addShard(String endpoint, int virtualNodeAmount);
 
-	String forwardRequest(String request, String identifier);
+	void forwardRequest(Request request, String identifier);
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingService.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingService.java
@@ -1,0 +1,7 @@
+package com.jinyframework.keva.proxy.balance;
+
+public interface LoadBalancingService {
+	void addShard(String endpoint, int virtualNodeAmount);
+
+	String forwardRequest(String request, String identifier);
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingServiceImpl.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingServiceImpl.java
@@ -1,0 +1,66 @@
+package com.jinyframework.keva.proxy.balance;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutionException;
+
+import com.jinyframework.keva.proxy.util.HashUtil;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoadBalancingServiceImpl implements LoadBalancingService {
+	private static final String SHARD_KEY = "shard_key";
+	//Map of shard key and its corresponding shard connection
+	private final ConcurrentHashMap<Long , Shard> shards = new ConcurrentHashMap<>();
+	//Map of virtual node to use in consistent hashing
+	private final ConcurrentSkipListMap<Long, Long> virtualNodes = new ConcurrentSkipListMap<>();
+
+	private static InetSocketAddress parseEndpoint(String addr) {
+		final String[] s = addr.split(":");
+		final String host = s[0];
+		final int port = Integer.parseInt(s[1]);
+		return new InetSocketAddress(host, port);
+	}
+
+	private Shard getShard(String identifier) {
+		ConcurrentNavigableMap<Long, Long> subMap = virtualNodes.tailMap(HashUtil.hash(identifier));
+		Long key;
+		if(subMap.isEmpty()){
+			//If there is no one larger than the hash value of the key, start with the first node
+			key = virtualNodes.firstKey();
+		} else{
+			//The first Key is the nearest node clockwise past the node.
+			key = subMap.firstKey();
+		}
+		return shards.get(virtualNodes.get(key));
+	}
+
+	private static void forwardShardKey(Shard shard, long key) {
+		shard.send("set " + SHARD_KEY + " " + key);
+	}
+
+	@Override
+	public void addShard(String endpoint, int virtualNodeAmount) {
+		final InetSocketAddress addr = parseEndpoint(endpoint);
+		final Shard shard = new Shard(addr.getHostName(), addr.getPort());
+		long shardKey = HashUtil.hash(endpoint);
+		forwardShardKey(shard, shardKey);
+		shards.put(shardKey, shard);
+		for (int i = 0; i < virtualNodeAmount; i++) {
+			virtualNodes.put(HashUtil.hash(endpoint + "VN" + i), shardKey);
+		}
+	}
+
+	@Override
+	public String forwardRequest(String request, String identifier) {
+		Shard shard = this.getShard(identifier);
+		try {
+			return (String) shard.send(request).get();
+		} catch (InterruptedException | ExecutionException e) {
+			log.error(e.getMessage());
+			return "Something wrong happen";
+		}
+	}
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingServiceImpl.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingServiceImpl.java
@@ -11,9 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class LoadBalancingServiceImpl implements LoadBalancingService {
-	private static final String SHARD_KEY = "shard_key";
 	//Map of shard key and its corresponding shard connection
-	private final ConcurrentHashMap<Long , Shard> shards = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<Long, Shard> shards = new ConcurrentHashMap<>();
 	//Map of virtual node to use in consistent hashing
 	private final ConcurrentSkipListMap<Long, Long> virtualNodes = new ConcurrentSkipListMap<>();
 
@@ -27,18 +26,14 @@ public class LoadBalancingServiceImpl implements LoadBalancingService {
 	private Shard getShard(String identifier) {
 		ConcurrentNavigableMap<Long, Long> subMap = virtualNodes.tailMap(HashUtil.hash(identifier));
 		Long key;
-		if(subMap.isEmpty()){
+		if (subMap.isEmpty()) {
 			//If there is no one larger than the hash value of the key, start with the first node
 			key = virtualNodes.firstKey();
-		} else{
+		} else {
 			//The first Key is the nearest node clockwise past the node.
 			key = subMap.firstKey();
 		}
 		return shards.get(virtualNodes.get(key));
-	}
-
-	private static void forwardShardKey(Shard shard, long key) {
-		shard.send("set " + SHARD_KEY + " " + key);
 	}
 
 	@Override
@@ -46,7 +41,6 @@ public class LoadBalancingServiceImpl implements LoadBalancingService {
 		final InetSocketAddress addr = parseEndpoint(endpoint);
 		final Shard shard = new Shard(addr.getHostName(), addr.getPort());
 		long shardKey = HashUtil.hash(endpoint);
-		forwardShardKey(shard, shardKey);
 		shards.put(shardKey, shard);
 		for (int i = 0; i < virtualNodeAmount; i++) {
 			virtualNodes.put(HashUtil.hash(endpoint + "VN" + i), shardKey);
@@ -54,14 +48,8 @@ public class LoadBalancingServiceImpl implements LoadBalancingService {
 	}
 
 	@Override
-	public String forwardRequest(String request, String identifier) {
+	public void forwardRequest(Request request, String identifier) {
 		Shard shard = this.getShard(identifier);
-		try {
-			return (String) shard.send(request).get();
-		} catch (InterruptedException | ExecutionException e) {
-			log.error(e.getMessage());
-			Thread.currentThread().interrupt();
-			return "Something wrong happen";
-		}
+		shard.buffer(request);
 	}
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingServiceImpl.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/LoadBalancingServiceImpl.java
@@ -60,6 +60,7 @@ public class LoadBalancingServiceImpl implements LoadBalancingService {
 			return (String) shard.send(request).get();
 		} catch (InterruptedException | ExecutionException e) {
 			log.error(e.getMessage());
+			Thread.currentThread().interrupt();
 			return "Something wrong happen";
 		}
 	}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/Request.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/Request.java
@@ -1,0 +1,14 @@
+package com.jinyframework.keva.proxy.balance;
+
+import io.netty.channel.ChannelHandlerContext;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class Request {
+	private ChannelHandlerContext channelContext;
+	private String requestContent = "";
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/Shard.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/Shard.java
@@ -1,0 +1,78 @@
+package com.jinyframework.keva.proxy.balance;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.jinyframework.keva.proxy.core.StringCodecLineFrameInitializer;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public class Shard {
+	private static final EventLoopGroup workerGroup = new NioEventLoopGroup();
+	private final AtomicLong lastCommunicated;
+	private final String host;
+	private final int port;
+	Bootstrap b;
+	private Channel channel;
+
+	public Shard(String host, int port) {
+		this.host = host;
+		this.port = port;
+		lastCommunicated = new AtomicLong(System.currentTimeMillis());
+	}
+
+	public void init() {
+		b = new Bootstrap();
+		b.group(workerGroup)
+			.channel(NioSocketChannel.class)
+			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+			.option(ChannelOption.SO_KEEPALIVE, true)
+			.handler(new LoggingHandler(LogLevel.INFO))
+			.handler(new StringCodecLineFrameInitializer());
+	}
+
+	public boolean connect() {
+		if (channel != null) {
+			return true;
+		}
+		if (b == null) {
+			init();
+		}
+		int count = 0;
+		while (count < 3) {
+			final ChannelFuture future = b.connect(host, port).awaitUninterruptibly();
+			if (future.isSuccess()) {
+				channel = future.channel();
+				return true;
+			} else {
+				count++;
+			}
+		}
+		return false;
+	}
+
+	public CompletableFuture<Object> send(String msg) {
+		final CompletableFuture<Object> resPromise = new CompletableFuture<>();
+		// lazy initialization, only try to connect when sending
+		if (!connect()) {
+			resPromise.completeExceptionally(new IOException("Lost connection to server"));
+			return resPromise;
+		}
+		channel.pipeline().addLast(new ShardHandler(resPromise));
+		channel.write(msg);
+		channel.writeAndFlush("\n");
+		return resPromise;
+	}
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/balance/ShardHandler.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/balance/ShardHandler.java
@@ -1,0 +1,33 @@
+package com.jinyframework.keva.proxy.balance;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+public class ShardHandler extends SimpleChannelInboundHandler<String> {
+	private final CompletableFuture<Object> resPromise;
+
+	public ShardHandler(CompletableFuture<Object> resPromise) {
+		this.resPromise = resPromise;
+	}
+
+	@Override
+	protected void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception {
+		resPromise.complete(msg);
+	}
+
+	@Override
+	public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+		super.channelReadComplete(ctx);
+		ctx.channel().pipeline().remove(this);
+		ctx.flush();
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		super.exceptionCaught(ctx, cause);
+		resPromise.completeExceptionally(cause);
+		ctx.close();
+	}
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandHandler.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandHandler.java
@@ -1,0 +1,10 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.util.List;
+
+import io.netty.channel.ChannelHandlerContext;
+
+@FunctionalInterface
+public interface CommandHandler {
+	void handle(ChannelHandlerContext ctx, String line);
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandName.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandName.java
@@ -1,0 +1,12 @@
+package com.jinyframework.keva.proxy.command;
+
+public enum CommandName {
+    GET,
+    SET,
+    PING,
+    INFO,
+    DEL,
+    EXPIRE,
+    FSYNC,
+    UNSUPPORTED
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandRegistrar.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandRegistrar.java
@@ -1,0 +1,35 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.jinyframework.keva.server.command.CommandHandler;
+import lombok.val;
+
+public final class CommandRegistrar {
+    private CommandRegistrar() {
+    }
+
+    public static Map<CommandName, CommandHandler> getHandlerMap() {
+        return RegistrarHolder.registrar;
+    }
+
+    private static final class RegistrarHolder {
+        static final Map<CommandName, CommandHandler> registrar = registerCommands();
+
+        private static Map<CommandName, CommandHandler> registerCommands() {
+            val map = new HashMap<CommandName, CommandHandler>();
+            map.put(CommandName.GET, new Forward());
+            map.put(CommandName.SET, new Forward());
+            map.put(CommandName.PING, new Ping());
+            map.put(CommandName.INFO, new Info());
+            map.put(CommandName.DEL, new Forward());
+            map.put(CommandName.EXPIRE, new Forward());
+            map.put(CommandName.FSYNC, new Forward());
+
+            map.put(CommandName.UNSUPPORTED, new Unsupported());
+            return Collections.unmodifiableMap(map);
+        }
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandRegistrar.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandRegistrar.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import command.CommandHandler;
 import lombok.val;
 
 public final class CommandRegistrar {

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandRegistrar.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandRegistrar.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.jinyframework.keva.server.command.CommandHandler;
+import command.CommandHandler;
 import lombok.val;
 
 public final class CommandRegistrar {

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandService.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandService.java
@@ -15,5 +15,5 @@ public interface CommandService {
         return String.join(" ", tokens);
     }
 
-    Object handleCommand(ChannelHandlerContext ctx, String line);
+    void handleCommand(ChannelHandlerContext ctx, String line);
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandService.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandService.java
@@ -1,0 +1,19 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.netty.channel.ChannelHandlerContext;
+
+public interface CommandService {
+    static ArrayList<String> parseTokens(String line) {
+        return new ArrayList<>(Arrays.asList(line.split(" ")));
+    }
+
+    static String parseLine(List<String> tokens) {
+        return String.join(" ", tokens);
+    }
+
+    Object handleCommand(ChannelHandlerContext ctx, String line);
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandServiceImpl.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandServiceImpl.java
@@ -1,0 +1,34 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.util.Map;
+
+import com.jinyframework.keva.server.command.CommandHandler;
+import io.netty.channel.ChannelHandlerContext;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+@Slf4j
+public class CommandServiceImpl implements CommandService {
+    private final Map<CommandName, CommandHandler> commandHandlerMap = CommandRegistrar.getHandlerMap();
+
+    @Override
+    public Object handleCommand(ChannelHandlerContext ctx, String line) {
+        Object output;
+        try {
+            val args = CommandService.parseTokens(line);
+            CommandName command;
+            try {
+                command = CommandName.valueOf(args.get(0).toUpperCase());
+            } catch (IllegalArgumentException e) {
+                command = CommandName.UNSUPPORTED;
+            }
+
+            val handler = commandHandlerMap.get(command);
+            output = handler.handle(args);
+        } catch (Exception e) {
+            log.error("Error while handling command: ", e);
+            output = "ERROR";
+        }
+        return output;
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandServiceImpl.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandServiceImpl.java
@@ -2,7 +2,6 @@ package com.jinyframework.keva.proxy.command;
 
 import java.util.Map;
 
-import command.CommandHandler;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -12,8 +11,7 @@ public class CommandServiceImpl implements CommandService {
     private final Map<CommandName, CommandHandler> commandHandlerMap = CommandRegistrar.getHandlerMap();
 
     @Override
-    public Object handleCommand(ChannelHandlerContext ctx, String line) {
-        Object output;
+    public void handleCommand(ChannelHandlerContext ctx, String line) {
         try {
             val args = CommandService.parseTokens(line);
             CommandName command;
@@ -24,11 +22,9 @@ public class CommandServiceImpl implements CommandService {
             }
 
             val handler = commandHandlerMap.get(command);
-            output = handler.handle(args);
+            handler.handle(ctx, line);
         } catch (Exception e) {
             log.error("Error while handling command: ", e);
-            output = "ERROR";
         }
-        return output;
     }
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandServiceImpl.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/CommandServiceImpl.java
@@ -2,7 +2,7 @@ package com.jinyframework.keva.proxy.command;
 
 import java.util.Map;
 
-import com.jinyframework.keva.server.command.CommandHandler;
+import command.CommandHandler;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Forward.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Forward.java
@@ -1,0 +1,14 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.util.List;
+
+import com.jinyframework.keva.proxy.ServiceInstance;
+import com.jinyframework.keva.server.command.CommandHandler;
+
+public class Forward implements CommandHandler {
+	@Override
+	public Object handle(List<String> args) {
+		String request = CommandService.parseLine(args);
+		return ServiceInstance.getLoadBalancingService().forwardRequest(request, args.get(1));
+	}
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Forward.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Forward.java
@@ -3,7 +3,7 @@ package com.jinyframework.keva.proxy.command;
 import java.util.List;
 
 import com.jinyframework.keva.proxy.ServiceInstance;
-import com.jinyframework.keva.server.command.CommandHandler;
+import command.CommandHandler;
 
 public class Forward implements CommandHandler {
 	@Override

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Forward.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Forward.java
@@ -3,12 +3,14 @@ package com.jinyframework.keva.proxy.command;
 import java.util.List;
 
 import com.jinyframework.keva.proxy.ServiceInstance;
-import command.CommandHandler;
+import com.jinyframework.keva.proxy.balance.Request;
+import io.netty.channel.ChannelHandlerContext;
+import lombok.val;
 
 public class Forward implements CommandHandler {
 	@Override
-	public Object handle(List<String> args) {
-		String request = CommandService.parseLine(args);
-		return ServiceInstance.getLoadBalancingService().forwardRequest(request, args.get(1));
+	public void handle(ChannelHandlerContext ctx, String line) {
+		val args = CommandService.parseTokens(line);
+		ServiceInstance.getLoadBalancingService().forwardRequest(new Request(ctx, line), args.get(1));
 	}
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Info.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Info.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.jinyframework.keva.proxy.ServiceInstance;
-import com.jinyframework.keva.server.command.CommandHandler;
+import command.CommandHandler;
 
 public class Info implements CommandHandler {
     @Override

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Info.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Info.java
@@ -5,16 +5,17 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.jinyframework.keva.proxy.ServiceInstance;
-import command.CommandHandler;
+import io.netty.channel.ChannelHandlerContext;
 
 public class Info implements CommandHandler {
     @Override
-    public String handle(List<String> args) {
+    public void handle(ChannelHandlerContext ctx, String line) {
         final HashMap<String, Object> stats = new HashMap<>();
         final long currentConnectedClients = ServiceInstance.getConnectionService().getCurrentConnectedClients();
         final int threads = ManagementFactory.getThreadMXBean().getThreadCount();
         stats.put("clients:", currentConnectedClients);
         stats.put("threads:", threads);
-        return stats.toString();
+        ctx.write(stats.toString());
+        ctx.flush();
     }
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Info.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Info.java
@@ -1,0 +1,20 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.List;
+
+import com.jinyframework.keva.proxy.ServiceInstance;
+import com.jinyframework.keva.server.command.CommandHandler;
+
+public class Info implements CommandHandler {
+    @Override
+    public String handle(List<String> args) {
+        final HashMap<String, Object> stats = new HashMap<>();
+        final long currentConnectedClients = ServiceInstance.getConnectionService().getCurrentConnectedClients();
+        final int threads = ManagementFactory.getThreadMXBean().getThreadCount();
+        stats.put("clients:", currentConnectedClients);
+        stats.put("threads:", threads);
+        return stats.toString();
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Ping.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Ping.java
@@ -2,7 +2,7 @@ package com.jinyframework.keva.proxy.command;
 
 import java.util.List;
 
-import com.jinyframework.keva.server.command.CommandHandler;
+import command.CommandHandler;
 
 public class Ping implements CommandHandler {
     @Override

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Ping.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Ping.java
@@ -1,12 +1,11 @@
 package com.jinyframework.keva.proxy.command;
 
-import java.util.List;
-
-import command.CommandHandler;
+import io.netty.channel.ChannelHandlerContext;
 
 public class Ping implements CommandHandler {
     @Override
-    public String handle(List<String> args) {
-        return "PONG";
+    public void handle(ChannelHandlerContext ctx, String line) {
+       ctx.write("PONG");
+       ctx.flush();
     }
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Ping.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Ping.java
@@ -1,0 +1,12 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.util.List;
+
+import com.jinyframework.keva.server.command.CommandHandler;
+
+public class Ping implements CommandHandler {
+    @Override
+    public String handle(List<String> args) {
+        return "PONG";
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Unsupported.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Unsupported.java
@@ -2,7 +2,7 @@ package com.jinyframework.keva.proxy.command;
 
 import java.util.List;
 
-import com.jinyframework.keva.server.command.CommandHandler;
+import command.CommandHandler;
 
 public class Unsupported implements CommandHandler {
     @Override

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Unsupported.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Unsupported.java
@@ -1,0 +1,12 @@
+package com.jinyframework.keva.proxy.command;
+
+import java.util.List;
+
+import com.jinyframework.keva.server.command.CommandHandler;
+
+public class Unsupported implements CommandHandler {
+    @Override
+    public String handle(List<String> args) {
+        return "Unsupported command";
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/command/Unsupported.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/command/Unsupported.java
@@ -2,11 +2,12 @@ package com.jinyframework.keva.proxy.command;
 
 import java.util.List;
 
-import command.CommandHandler;
+import io.netty.channel.ChannelHandlerContext;
 
 public class Unsupported implements CommandHandler {
     @Override
-    public String handle(List<String> args) {
-        return "Unsupported command";
+    public void handle(ChannelHandlerContext ctx, String line) {
+        ctx.write("Unsupported command");
+        ctx.flush();
     }
 }

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigHolder.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigHolder.java
@@ -1,0 +1,104 @@
+package com.jinyframework.keva.proxy.config;
+
+import java.util.Properties;
+
+import com.jinyframework.keva.server.config.CliProp;
+import com.jinyframework.keva.server.config.CliPropType;
+import com.jinyframework.keva.server.config.ConfigProp;
+import com.jinyframework.keva.server.util.ArgsHolder;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import lombok.ToString;
+import lombok.val;
+
+@Builder(toBuilder = true)
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class ConfigHolder {
+
+    @ConfigProp(name = "hostname", defaultVal = "localhost")
+    @CliProp(name = "h", type = CliPropType.VAL)
+    private String hostname;
+
+    @ConfigProp(name = "port", defaultVal = "6767")
+    @CliProp(name = "p", type = CliPropType.VAL)
+    private Integer port;
+
+    @ConfigProp(name = "server_list", defaultVal = "")
+    @CliProp(name = "sl", type = CliPropType.VAL)
+    private String serverList;
+
+    @ConfigProp(name = "virtual_node_amount", defaultVal = "3")
+    @CliProp(name = "vna", type = CliPropType.VAL)
+    private Integer virtualNodeAmount;
+
+    @SneakyThrows
+    public static ConfigHolder fromProperties(@NonNull Properties props) {
+        val configHolder = builder().build();
+        val fields = ConfigHolder.class.getDeclaredFields();
+        for (val field : fields) {
+            if (field.isAnnotationPresent(ConfigProp.class)) {
+                val annotation = field.getAnnotation(ConfigProp.class);
+                val value = parse(props.getProperty(annotation.name(), annotation.defaultVal()), field.getType());
+                field.set(configHolder, value);
+            }
+        }
+
+        return configHolder;
+    }
+
+    @SneakyThrows
+    public static ConfigHolder fromArgs(@NonNull ArgsHolder args) {
+        val configHolder = builder().build();
+
+        val fields = ConfigHolder.class.getDeclaredFields();
+        for (val field : fields) {
+            if (field.isAnnotationPresent(CliProp.class)) {
+                val cliAnnotate = field.getAnnotation(CliProp.class);
+                String strVal = null;
+                if (cliAnnotate.type() == CliPropType.VAL) {
+                    strVal = args.getArgVal(cliAnnotate.name());
+                } else if (cliAnnotate.type() == CliPropType.FLAG) {
+                    strVal = args.getFlag(cliAnnotate.name());
+                }
+                if (strVal != null) {
+                    val value = parse(strVal, field.getType());
+                    field.set(configHolder, value);
+                }
+            }
+        }
+
+        return configHolder;
+    }
+
+    @SneakyThrows
+    private static <T> T parse(String s, Class<T> clazz) {
+        return clazz.getConstructor(String.class).newInstance(s);
+    }
+
+    public static ConfigHolderBuilder defaultBuilder() {
+        return builder()
+                .hostname("localhost")
+                .port(6767);
+    }
+
+    @SneakyThrows
+    public ConfigHolder merge(ConfigHolder overrideHolder) {
+        if (overrideHolder != null && !equals(overrideHolder)) {
+            for (val field : overrideHolder.getClass().getDeclaredFields()) {
+                val overrideVal = field.get(overrideHolder);
+                if (overrideVal != null) {
+                    field.set(this, overrideVal);
+                }
+            }
+            return this;
+        }
+        return this;
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigHolder.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigHolder.java
@@ -2,10 +2,9 @@ package com.jinyframework.keva.proxy.config;
 
 import java.util.Properties;
 
-import com.jinyframework.keva.server.config.CliProp;
-import com.jinyframework.keva.server.config.CliPropType;
-import com.jinyframework.keva.server.config.ConfigProp;
-import com.jinyframework.keva.server.util.ArgsHolder;
+import config.config.CliProp;
+import config.config.CliPropType;
+import config.config.ConfigProp;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -14,6 +13,7 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.ToString;
 import lombok.val;
+import util.ArgsHolder;
 
 @Builder(toBuilder = true)
 @Getter

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigManager.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigManager.java
@@ -1,0 +1,44 @@
+package com.jinyframework.keva.proxy.config;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import com.jinyframework.keva.server.util.ArgsParser;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+@Slf4j
+public class ConfigManager {
+	public static final String DEFAULT_FILE_PATH = Paths.get(".", "proxy.properties").toString();
+
+	private ConfigManager() {
+	}
+
+	public static ConfigHolder loadConfig(String[] args) throws IOException {
+		ConfigHolder returnConf = ConfigHolder.fromProperties(new Properties());
+		val config = ArgsParser.parse(args);
+		log.info(config.toString());
+		val overrider = ConfigHolder.fromArgs(config);
+
+		val configFilePath = config.getArgVal("f");
+		if (configFilePath != null) {
+			returnConf = loadConfigFromFile(configFilePath);
+		}
+
+		return returnConf.merge(overrider);
+	}
+
+	public static ConfigHolder loadConfigFromFile(String filePath) throws IOException {
+		if (filePath.isEmpty()) {
+			filePath = DEFAULT_FILE_PATH;
+		}
+		val props = new Properties();
+		try (val file = new FileInputStream(filePath)) {
+			props.load(file);
+		}
+
+		return ConfigHolder.fromProperties(props);
+	}
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigManager.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/config/ConfigManager.java
@@ -5,9 +5,9 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Properties;
 
-import com.jinyframework.keva.server.util.ArgsParser;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import util.ArgsParser;
 
 @Slf4j
 public class ConfigManager {

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/core/NettyServer.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/core/NettyServer.java
@@ -2,7 +2,6 @@ package com.jinyframework.keva.proxy.core;
 
 import com.jinyframework.keva.proxy.ServiceInstance;
 import com.jinyframework.keva.proxy.config.ConfigHolder;
-import com.jinyframework.keva.server.core.IServer;
 import com.jinyframework.keva.store.NoHeapConfig;
 import com.jinyframework.keva.store.NoHeapFactory;
 import com.jinyframework.keva.store.NoHeapStore;
@@ -15,6 +14,7 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import server.IServer;
 
 @Slf4j
 public class NettyServer implements IServer {
@@ -51,10 +51,10 @@ public class NettyServer implements IServer {
         log.info("Bootstrapped " + storageName);
     }
 
-    public void bootstrapShards() throws Exception {
+    public void bootstrapShards() {
         val servers = config.getServerList().split(",");
         if (servers.length == 0 || servers[0].isEmpty()) {
-            throw new Exception("No shard server defined");
+            throw new IllegalArgumentException("No shard server defined");
         }
         for (String server : servers) {
             ServiceInstance.getLoadBalancingService().addShard(server, config.getVirtualNodeAmount());

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/core/NettyServer.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/core/NettyServer.java
@@ -21,9 +21,7 @@ public class NettyServer implements IServer {
     static final ServerHandler SERVER_HANDLER = new ServerHandler();
     private final ConfigHolder config;
     EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-    // Should only use 1 thread to handle to keep order of commands
     EventLoopGroup workerGroup = new NioEventLoopGroup(1);
-
 
     public NettyServer(ConfigHolder config) {
         this.config = config;

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/core/NettyServer.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/core/NettyServer.java
@@ -1,0 +1,90 @@
+package com.jinyframework.keva.proxy.core;
+
+import com.jinyframework.keva.proxy.ServiceInstance;
+import com.jinyframework.keva.proxy.config.ConfigHolder;
+import com.jinyframework.keva.server.core.IServer;
+import com.jinyframework.keva.store.NoHeapConfig;
+import com.jinyframework.keva.store.NoHeapFactory;
+import com.jinyframework.keva.store.NoHeapStore;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+@Slf4j
+public class NettyServer implements IServer {
+    static final ServerHandler SERVER_HANDLER = new ServerHandler();
+    private final ConfigHolder config;
+    EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+    // Should only use 1 thread to handle to keep order of commands
+    EventLoopGroup workerGroup = new NioEventLoopGroup(1);
+
+
+    public NettyServer(ConfigHolder config) {
+        this.config = config;
+    }
+
+    public ServerBootstrap bootstrapServer() {
+        final ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup)
+         .channel(NioServerSocketChannel.class)
+         .handler(new LoggingHandler(LogLevel.INFO))
+         .childHandler(new StringCodecLineFrameInitializer(SERVER_HANDLER));
+        return b;
+    }
+
+    public void bootstrapStorage() {
+        val noHeapConfig = NoHeapConfig.builder()
+                                       .heapSize(64)
+                                       .snapshotEnabled(false)
+                                       .snapshotLocation("./")
+                                       .build();
+        final NoHeapStore noHeapStore = NoHeapFactory.makeNoHeapDBStore(noHeapConfig);
+        ServiceInstance.getStorageService().setStore(noHeapStore);
+
+        val storageName = noHeapStore.getName();
+        log.info("Bootstrapped " + storageName);
+    }
+
+    public void bootstrapShards() throws Exception {
+        val servers = config.getServerList().split(",");
+        if (servers.length == 0 || servers[0].isEmpty()) {
+            throw new Exception("No shard server defined");
+        }
+        for (String server : servers) {
+            ServiceInstance.getLoadBalancingService().addShard(server, config.getVirtualNodeAmount());
+            log.info("Added shard server: " + server);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+    }
+
+    @Override
+    public void run() {
+        try {
+            bootstrapStorage();
+            bootstrapShards();
+            final ServerBootstrap server = bootstrapServer();
+            final ChannelFuture sync = server.bind(config.getPort()).sync();
+
+            sync.channel().closeFuture().sync();
+        } catch (InterruptedException e) {
+            log.error("Failed to start server: ", e);
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            log.error("Failed to start server: ", e);
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/core/ServerHandler.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/core/ServerHandler.java
@@ -1,0 +1,64 @@
+package com.jinyframework.keva.proxy.core;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+
+import com.jinyframework.keva.proxy.ServiceInstance;
+import com.jinyframework.keva.proxy.command.CommandService;
+import com.jinyframework.keva.server.core.ClientInfo;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.util.AttributeKey;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ChannelHandler.Sharable
+public class ServerHandler extends SimpleChannelInboundHandler<String> {
+    private final ConcurrentMap<String, ClientInfo> clients = ServiceInstance.getConnectionService().getClients();
+    private final CommandService commandService = ServiceInstance.getCommandService();
+
+    private final AttributeKey<String> sockIdKey = AttributeKey.newInstance("proxySocketId");
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, String msg) {
+        Object res = commandService.handleCommand(ctx, msg);
+        if (res == null) {
+            res = "null";
+        }
+        ctx.write(res);
+        ctx.writeAndFlush("\n");
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        super.channelRegistered(ctx);
+        final String socketId = UUID.randomUUID().toString();
+        final String remoteAddr = ctx.channel().remoteAddress().toString();
+        ctx.channel().attr(sockIdKey).setIfAbsent(socketId);
+        clients.put(socketId, ClientInfo.builder()
+                                        .id(socketId)
+                                        .build());
+        log.debug("{} {} connected", remoteAddr, socketId);
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        super.channelUnregistered(ctx);
+        final String remoteAddr = ctx.channel().remoteAddress().toString();
+        final String socketId = ctx.channel().attr(sockIdKey).get();
+        clients.remove(socketId);
+        log.debug("{} {} disconnected", remoteAddr, socketId);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Handler exception caught: ", cause);
+        ctx.close();
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/core/ServerHandler.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/core/ServerHandler.java
@@ -22,12 +22,7 @@ public class ServerHandler extends SimpleChannelInboundHandler<String> {
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, String msg) {
-        Object res = commandService.handleCommand(ctx, msg);
-        if (res == null) {
-            res = "null";
-        }
-        ctx.write(res);
-        ctx.writeAndFlush("\n");
+        commandService.handleCommand(ctx, msg);
     }
 
     @Override

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/core/ServerHandler.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/core/ServerHandler.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import com.jinyframework.keva.proxy.ServiceInstance;
 import com.jinyframework.keva.proxy.command.CommandService;
-import com.jinyframework.keva.server.core.ClientInfo;
+import connection.ClientInfo;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/core/StringCodecLineFrameInitializer.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/core/StringCodecLineFrameInitializer.java
@@ -1,0 +1,43 @@
+package com.jinyframework.keva.proxy.core;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.DelimiterBasedFrameDecoder;
+import io.netty.handler.codec.Delimiters;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import io.netty.util.CharsetUtil;
+
+public class StringCodecLineFrameInitializer extends ChannelInitializer<SocketChannel> {
+    private static final StringDecoder DECODER = new StringDecoder(CharsetUtil.UTF_8);
+    private static final StringEncoder ENCODER = new StringEncoder(CharsetUtil.UTF_8);
+
+    private ChannelHandler handler;
+
+    public StringCodecLineFrameInitializer(ChannelHandler handler) {
+        this.handler = handler;
+    }
+
+    public StringCodecLineFrameInitializer() {
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) throws Exception {
+        ch.config().setKeepAlive(true);
+        final ChannelPipeline pipeline = ch.pipeline();
+
+        // Add the text line codec combination first,
+        final int maxFrameLength = 1024 * 1024 * 64; // hardcode 64MB for now
+        pipeline.addLast(new DelimiterBasedFrameDecoder(maxFrameLength, Delimiters.lineDelimiter()));
+
+        pipeline.addLast(DECODER);
+        pipeline.addLast(ENCODER);
+
+        // and then business logic.
+        if (handler != null) {
+            pipeline.addLast(handler);
+        }
+    }
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/util/HashUtil.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/util/HashUtil.java
@@ -1,0 +1,35 @@
+package com.jinyframework.keva.proxy.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * @author tuna
+ */
+public class HashUtil {
+	private static MessageDigest instance = null;
+
+	static {
+		try {
+			instance = MessageDigest.getInstance("MD5");
+		} catch (NoSuchAlgorithmException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private HashUtil() {
+	}
+
+	public static long hash(String value) {
+		instance.reset();
+		instance.update(value.getBytes());
+		byte[] digest = instance.digest();
+
+		long h = 0;
+		for (int i = 0; i < 4; i++) {
+			h <<= 8;
+			h |= ((int) digest[i]) & 0xFF;
+		}
+		return h;
+	}
+}

--- a/proxy/src/main/java/com/jinyframework/keva/proxy/util/HashUtil.java
+++ b/proxy/src/main/java/com/jinyframework/keva/proxy/util/HashUtil.java
@@ -11,9 +11,9 @@ public class HashUtil {
 
 	static {
 		try {
-			instance = MessageDigest.getInstance("MD5");
+			instance = MessageDigest.getInstance("SHA-256");
 		} catch (NoSuchAlgorithmException e) {
-			e.printStackTrace();
+			//Do nothing
 		}
 	}
 

--- a/proxy/src/test/java/com/jinyframework/keva/server/AbstractProxyTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/AbstractProxyTest.java
@@ -12,11 +12,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import server.IServer;
 import util.SocketClient;
 
-public abstract class AbstractServerTest {
+@Slf4j
+public abstract class AbstractProxyTest {
     static SocketClient client;
     static IServer server;
 
@@ -44,7 +46,9 @@ public abstract class AbstractServerTest {
     @Test
     void getSetNull() {
         try {
+            log.info("Start get null test");
             val getNull = client.exchange("get anotherkey");
+            log.info("Got result");
             assertEquals("null", getNull);
         } catch (Exception e) {
             fail(e);

--- a/proxy/src/test/java/com/jinyframework/keva/server/AbstractServerTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/AbstractServerTest.java
@@ -1,0 +1,115 @@
+package com.jinyframework.keva.server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.jinyframework.keva.server.core.IServer;
+import com.jinyframework.keva.server.util.SocketClient;
+import lombok.val;
+
+public abstract class AbstractServerTest {
+    static SocketClient client;
+    static IServer server;
+
+    @Test
+    void ping() {
+        try {
+            val pong = client.exchange("ping");
+            assertTrue("PONG".contentEquals(pong));
+            assertEquals("PONG", pong);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void info() {
+        try {
+            val info = client.exchange("info");
+            assertFalse("null".contentEquals(info));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void getSetNull() {
+        try {
+            val getNull = client.exchange("get anotherkey");
+            assertEquals("null", getNull);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void getSet() {
+        try {
+            val setAbc = client.exchange("set abc 123");
+            val getAbc = client.exchange("get abc");
+            assertEquals("1", setAbc);
+            assertEquals("123", getAbc);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void del() {
+        try {
+            val setAbc = client.exchange("set abc 123");
+            val getAbc = client.exchange("get abc");
+            val delAbc = client.exchange("del abc");
+            val getAbcNull = client.exchange("get abc");
+            assertEquals("1", setAbc);
+            assertEquals("123", getAbc);
+            assertEquals("1", delAbc);
+            assertEquals("null", getAbcNull);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void multiClientGet() {
+        try {
+            val setAbc = client.exchange("set abc 123");
+            assertEquals("1", setAbc);
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        final List<Callable<Object>> tasks = new ArrayList<>();
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        final int taskNum = 2;
+        for (int i = 0; i < taskNum; i++) {
+            final int finalI = i;
+            tasks.add(() ->
+            {
+                System.out.println("task: " + finalI);
+                return client.exchange("get abc");
+            });
+        }
+        try {
+            final List<Future<Object>> futures = executor.invokeAll(tasks, 2, TimeUnit.SECONDS);
+            assertFalse(futures.isEmpty());
+            assertEquals(taskNum, futures.size());
+            for (Future<Object> future : futures) {
+                assertEquals("123", future.get().toString());
+            }
+
+            System.out.println(futures.size());
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+}

--- a/proxy/src/test/java/com/jinyframework/keva/server/AbstractServerTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/AbstractServerTest.java
@@ -12,9 +12,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
-import com.jinyframework.keva.server.core.IServer;
-import com.jinyframework.keva.server.util.SocketClient;
 import lombok.val;
+import server.IServer;
+import util.SocketClient;
 
 public abstract class AbstractServerTest {
     static SocketClient client;

--- a/proxy/src/test/java/com/jinyframework/keva/server/ProxyTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/ProxyTest.java
@@ -13,13 +13,12 @@ import com.jinyframework.keva.proxy.core.NettyServer;
 import com.jinyframework.keva.server.core.IServer;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-
 import util.PortUtil;
 import util.SocketClient;
 
 @Slf4j
 @DisplayName("Netty Server")
-public class ServerTest extends AbstractServerTest {
+public class ProxyTest extends AbstractProxyTest {
 	static String host = "localhost";
 	static List<IServer> shards = new ArrayList<>();
 

--- a/proxy/src/test/java/com/jinyframework/keva/server/ServerTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/ServerTest.java
@@ -1,0 +1,83 @@
+package com.jinyframework.keva.server;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+
+import com.jinyframework.keva.proxy.config.ConfigHolder;
+import com.jinyframework.keva.proxy.core.NettyServer;
+import com.jinyframework.keva.server.core.IServer;
+import com.jinyframework.keva.server.util.PortUtil;
+import com.jinyframework.keva.server.util.SocketClient;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+@Slf4j
+@DisplayName("Netty Server")
+public class ServerTest extends AbstractServerTest {
+	static String host = "localhost";
+	static List<IServer> shards = new ArrayList<>();
+
+	@BeforeAll
+	static void startServer() throws Exception {
+		int shard1Port = addShard();
+		int shard2Port = addShard();
+
+		int serverPort = PortUtil.getAvailablePort();
+		server = new NettyServer(ConfigHolder.defaultBuilder()
+			.hostname(host)
+			.port(serverPort)
+			.virtualNodeAmount(3)
+			.serverList(host + ":" + shard1Port + "," + host + ":" + shard2Port)
+			.build());
+
+		new Thread(() -> {
+			try {
+				server.run();
+			} catch (Exception e) {
+				log.error(e.getMessage());
+				System.exit(1);
+			}
+		}).start();
+
+		// Wait for server to start
+		TimeUnit.SECONDS.sleep(20);
+
+		client = new SocketClient(host, serverPort);
+		client.connect();
+	}
+
+	@AfterAll
+	static void stop() {
+		client.disconnect();
+		server.shutdown();
+		shards.forEach(IServer::shutdown);
+	}
+
+	// Return shard port (host is always local)
+	private static int addShard() throws InterruptedException {
+		val port= PortUtil.getAvailablePort();
+		IServer shard = new com.jinyframework.keva.server.core.NettyServer(com.jinyframework.keva.server.config.ConfigHolder.defaultBuilder()
+			.snapshotEnabled(false)
+			.hostname(host)
+			.port(port)
+			.build());
+
+		new Thread(() -> {
+			try {
+				shard.run();
+			} catch (Exception e) {
+				log.error(e.getMessage());
+				System.exit(1);
+			}
+		}).start();
+
+		TimeUnit.SECONDS.sleep(10);
+		shards.add(shard);
+		return port;
+	}
+}

--- a/proxy/src/test/java/com/jinyframework/keva/server/ServerTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/ServerTest.java
@@ -11,10 +11,11 @@ import org.junit.jupiter.api.DisplayName;
 import com.jinyframework.keva.proxy.config.ConfigHolder;
 import com.jinyframework.keva.proxy.core.NettyServer;
 import com.jinyframework.keva.server.core.IServer;
-import com.jinyframework.keva.server.util.PortUtil;
-import com.jinyframework.keva.server.util.SocketClient;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+
+import util.PortUtil;
+import util.SocketClient;
 
 @Slf4j
 @DisplayName("Netty Server")

--- a/proxy/src/test/java/com/jinyframework/keva/server/util/HashUtilTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/util/HashUtilTest.java
@@ -1,0 +1,17 @@
+package com.jinyframework.keva.server.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.jinyframework.keva.proxy.util.HashUtil;
+
+class HashUtilTest {
+
+    @Test
+    void hash() {
+        String key = "keva";
+        long hashValue = 1993468365;
+        assertEquals(hashValue, HashUtil.hash(key));
+    }
+}

--- a/proxy/src/test/java/com/jinyframework/keva/server/util/HashUtilTest.java
+++ b/proxy/src/test/java/com/jinyframework/keva/server/util/HashUtilTest.java
@@ -11,7 +11,7 @@ class HashUtilTest {
     @Test
     void hash() {
         String key = "keva";
-        long hashValue = 1993468365;
+        long hashValue = 3455670683L;
         assertEquals(hashValue, HashUtil.hash(key));
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,3 +4,5 @@ include 'cli-client'
 include 'server'
 include 'proxy'
 include 'store'
+include 'common'
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,5 @@ rootProject.name = 'keva'
 
 include 'cli-client'
 include 'server'
+include 'proxy'
 include 'store'


### PR DESCRIPTION
Add new module for **proxy** service
Flow: 
- Proxy server requires a set of shard server when initializing. The shard server should be the master
- When a request hit proxy server, it will determine which shard responsible for that key via a consistent hashing map
- Then proxy server will forward the request to corresponding shard
- Shard server will execute the request and return result to the proxy

Future improvements:
- Proxy module reuse many components from the server module. These components should be moved into a common module for future use.
- Method to update the shard master endpoint in case failure happen (Require sentinel feature)
- Feature to rebalance the data when new shard is added/removed
- Increase the amount of thread when handling requests in proxy (current is 1)

**How to test:**
Start shard 1 (use port 7272, turnoff snapshot feature):

`./gradlew server:run --args="-p 7272 -ss false"`

Start shard 2 (use port 7273, turnoff snapshot feature):

`./gradlew server:run --args="-p 7273 -ss false"`

Start proxy server
`./gradlew proxy:run --args="-sl localhost:7272,localhost:7273"`

Use netcat to test: `nc localhost 6767`