### PR TITLE
add EXPIRE and EXPIREAT passive strategy implementation and tests

### DIFF
--- a/docs/src/guide/overview/commands.md
+++ b/docs/src/guide/overview/commands.md
@@ -18,9 +18,9 @@ Implemented commands:
 
 - DEL
 - EXISTS
-- KEYS
 - RENAME
 - EXPIRE
+- EXPIREAT
 
 </details>
 

--- a/server/src/main/java/dev/keva/server/command/impl/key/Del.java
+++ b/server/src/main/java/dev/keva/server/command/impl/key/Del.java
@@ -6,6 +6,7 @@ import dev.keva.protocol.resp.reply.IntegerReply;
 import dev.keva.server.command.annotation.CommandImpl;
 import dev.keva.server.command.annotation.Execute;
 import dev.keva.server.command.annotation.ParamLength;
+import dev.keva.server.command.impl.key.manager.ExpirationManager;
 import dev.keva.store.KevaDatabase;
 
 import static dev.keva.server.command.annotation.ParamLength.Type.AT_LEAST;
@@ -15,10 +16,12 @@ import static dev.keva.server.command.annotation.ParamLength.Type.AT_LEAST;
 @ParamLength(type = AT_LEAST, value = 1)
 public class Del {
     private final KevaDatabase database;
+    private final ExpirationManager expirationManager;
 
     @Autowired
-    public Del(KevaDatabase database) {
+    public Del(KevaDatabase database, ExpirationManager expirationManager) {
         this.database = database;
+        this.expirationManager = expirationManager;
     }
 
     @Execute
@@ -27,6 +30,7 @@ public class Del {
         for (byte[] key : keys) {
             if (database.remove(key)) {
                 deleted++;
+                expirationManager.clearExpiration(key);
             }
         }
         return new IntegerReply(deleted);

--- a/server/src/main/java/dev/keva/server/command/impl/key/ExpireAt.java
+++ b/server/src/main/java/dev/keva/server/command/impl/key/ExpireAt.java
@@ -7,28 +7,25 @@ import dev.keva.server.command.annotation.CommandImpl;
 import dev.keva.server.command.annotation.Execute;
 import dev.keva.server.command.annotation.ParamLength;
 import dev.keva.server.command.impl.key.manager.ExpirationManager;
-import dev.keva.store.KevaDatabase;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Timer;
-import java.util.TimerTask;
 
 @Component
-@CommandImpl("expire")
+@CommandImpl("expireat")
 @ParamLength(2)
-public class Expire {
+public class ExpireAt {
     private final ExpirationManager expirationManager;
 
     @Autowired
-    public Expire(ExpirationManager expirationManager) {
+    public ExpireAt(ExpirationManager expirationManager) {
         this.expirationManager = expirationManager;
     }
 
     @Execute
-    public IntegerReply execute(byte[] key, byte[] after) {
+    public IntegerReply execute(byte[] key, byte[] at) {
         try {
-            var afterInMillis = Long.parseLong(new String(after, StandardCharsets.UTF_8));
-            expirationManager.expireAfter(key, afterInMillis);
+            var atInMillis = Long.parseLong(new String(at, StandardCharsets.UTF_8));
+            expirationManager.expireAt(key, atInMillis);
             return new IntegerReply(1);
         } catch (Exception ignore) {
             return new IntegerReply(0);

--- a/server/src/main/java/dev/keva/server/command/impl/key/Rename.java
+++ b/server/src/main/java/dev/keva/server/command/impl/key/Rename.java
@@ -6,6 +6,7 @@ import dev.keva.protocol.resp.reply.StatusReply;
 import dev.keva.server.command.annotation.CommandImpl;
 import dev.keva.server.command.annotation.Execute;
 import dev.keva.server.command.annotation.ParamLength;
+import dev.keva.server.command.impl.key.manager.ExpirationManager;
 import dev.keva.store.KevaDatabase;
 
 @Component
@@ -13,10 +14,12 @@ import dev.keva.store.KevaDatabase;
 @ParamLength(2)
 public class Rename {
     private final KevaDatabase database;
+    private final ExpirationManager expirationManager;
 
     @Autowired
-    public Rename(KevaDatabase database) {
+    public Rename(KevaDatabase database, ExpirationManager expirationManager) {
         this.database = database;
+        this.expirationManager = expirationManager;
     }
 
     @Execute
@@ -27,6 +30,7 @@ public class Rename {
         }
         database.put(newName, keyValue);
         database.remove(key);
+        expirationManager.move(key, newName);
         return StatusReply.OK;
     }
 }

--- a/server/src/main/java/dev/keva/server/command/impl/key/manager/ExpirationManager.java
+++ b/server/src/main/java/dev/keva/server/command/impl/key/manager/ExpirationManager.java
@@ -1,0 +1,60 @@
+package dev.keva.server.command.impl.key.manager;
+
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Longs;
+import dev.keva.ioc.annotation.Autowired;
+import dev.keva.ioc.annotation.Component;
+import dev.keva.store.KevaDatabase;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Component
+public class ExpirationManager {
+    private static final byte[] EXP_POSTFIX = new byte[]{(byte) 0x7f, (byte) 0x2f, (byte) 0x61, (byte) 0x74};
+    private final KevaDatabase database;
+    private final ExecutorService expireExecutor = Executors.newFixedThreadPool(1);
+
+    @Autowired
+    public ExpirationManager(KevaDatabase database) {
+        this.database = database;
+    }
+
+    public void expireAt(byte[] key, long at) {
+        byte[] expireKey = getExpireKey(key);
+        byte[] timestampInMillis = Longs.toByteArray(at);
+        if (at <= System.currentTimeMillis()) {
+            executeExpire(key);
+        } else {
+            database.put(expireKey, timestampInMillis);
+        }
+    }
+
+    public void expireAfter(byte[] key, long afterInSeconds) {
+        expireAt(key, System.currentTimeMillis() + afterInSeconds * 1000);
+    }
+
+    private byte[] getExpireKey(byte[] key) {
+        return Bytes.concat(key, EXP_POSTFIX);
+    }
+
+    public boolean isExpirable(byte[] key) {
+        byte[] longInBytes = database.get(getExpireKey(key));
+        if (longInBytes == null) {
+            return false;
+        } else {
+            return Longs.fromByteArray(longInBytes) <= System.currentTimeMillis();
+        }
+    }
+
+    public void clearExpiration(byte[] key) {
+        database.remove(getExpireKey(key));
+    }
+
+    public void executeExpire(byte[] key) {
+        expireExecutor.submit(() -> {
+            database.remove(key);
+            clearExpiration(key);
+        });
+    }
+}

--- a/server/src/main/java/dev/keva/server/command/impl/string/Set.java
+++ b/server/src/main/java/dev/keva/server/command/impl/string/Set.java
@@ -6,6 +6,7 @@ import dev.keva.protocol.resp.reply.StatusReply;
 import dev.keva.server.command.annotation.CommandImpl;
 import dev.keva.server.command.annotation.Execute;
 import dev.keva.server.command.annotation.ParamLength;
+import dev.keva.server.command.impl.key.manager.ExpirationManager;
 import dev.keva.store.KevaDatabase;
 
 @Component
@@ -13,15 +14,18 @@ import dev.keva.store.KevaDatabase;
 @ParamLength(2)
 public class Set {
     private final KevaDatabase database;
+    private final ExpirationManager expirationManager;
 
     @Autowired
-    public Set(KevaDatabase database) {
+    public Set(KevaDatabase database, ExpirationManager expirationManager) {
         this.database = database;
+        this.expirationManager = expirationManager;
     }
 
     @Execute
     public StatusReply execute(byte[] key, byte[] val) {
         database.put(key, val);
+        expirationManager.clearExpiration(key);
         return new StatusReply("OK");
     }
 }

--- a/server/src/test/java/dev/keva/server/core/AbstractServerTest.java
+++ b/server/src/test/java/dev/keva/server/core/AbstractServerTest.java
@@ -80,13 +80,38 @@ public abstract class AbstractServerTest {
     void getSetExpire() {
         try {
             val setAbc = jedis.set("abc", "123");
-            val getAbc = jedis.get("abc");
-            val expireAbc = jedis.expire("abc", 1);
+            var getAbc = jedis.get("abc");
+            val expireAbc = jedis.expire("abc", 1L);
 
             assertEquals("OK", setAbc);
             assertEquals("123", getAbc);
             assertEquals(1, expireAbc);
-            Thread.sleep(1500);
+            Thread.sleep(500);
+            getAbc = jedis.get("abc");
+            assertEquals("123", getAbc);
+            Thread.sleep(501);
+            val getAbcNull = jedis.get("abc");
+            assertNull(getAbcNull);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void getSetExpireAt() {
+        try {
+            val setAbc = jedis.set("abc", "123");
+            var getAbc = jedis.get("abc");
+            val oneSecondLaterTime = System.currentTimeMillis() + 1000;
+            val expireAbc = jedis.expireAt("abc", oneSecondLaterTime);
+
+            assertEquals("OK", setAbc);
+            assertEquals("123", getAbc);
+            assertEquals(1, expireAbc);
+            Thread.sleep(500);
+            getAbc = jedis.get("abc");
+            assertEquals("123", getAbc);
+            Thread.sleep(501);
             val getAbcNull = jedis.get("abc");
             assertNull(getAbcNull);
         } catch (Exception e) {


### PR DESCRIPTION
- command will store timestamp of expiration in database using key + special postfix
- actual delete happens in separate thread and only triggered when the key is queried after expiration time (hence passive)