### PR TITLE
Fix string deserialize exception

### DIFF
--- a/core/src/main/java/dev/keva/core/command/mapping/CommandMapper.java
+++ b/core/src/main/java/dev/keva/core/command/mapping/CommandMapper.java
@@ -19,6 +19,7 @@ import dev.keva.store.KevaDatabase;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.lang3.SerializationException;
 import org.reflections.Reflections;
 
 import java.lang.reflect.InvocationTargetException;
@@ -115,7 +116,7 @@ public class CommandMapper {
                         } catch (Exception e) {
                             log.error(e.getMessage(), e);
                             if (e instanceof InvocationTargetException) {
-                                if (e.getCause() instanceof ClassCastException) {
+                                if (e.getCause() instanceof SerializationException || e.getCause() instanceof ClassCastException) {
                                     return new ErrorReply("ERR WRONGTYPE Operation against a key holding the wrong kind of value");
                                 }
                                 return new ErrorReply("ERR " + e.getCause().getMessage());

--- a/core/src/test/java/dev/keva/core/server/AbstractServerTest.java
+++ b/core/src/test/java/dev/keva/core/server/AbstractServerTest.java
@@ -107,6 +107,39 @@ public abstract class AbstractServerTest {
     }
 
     @Test
+    void wrongTypeSet() {
+        try {
+            val setAbc = jedis.set("abc", "123");
+            assertEquals("OK", setAbc);
+            jedis.lpush("abc", "123");
+        } catch (Exception e) {
+            assertEquals(JedisDataException.class, e.getClass());
+        }
+    }
+
+    @Test
+    void wrongTypeSet2() {
+        try {
+            val setAbc = jedis.lpush("abc", "123");
+            assertEquals(1, setAbc);
+            jedis.hset("abc", "key", "val");
+        } catch (Exception e) {
+            assertEquals(JedisDataException.class, e.getClass());
+        }
+    }
+
+    @Test
+    void wrongTypeSet3() {
+        try {
+            val setAbc = jedis.hset("abc", "key", "val");
+            assertEquals(1, setAbc);
+            jedis.lpush("abc", "123");
+        } catch (Exception e) {
+            assertEquals(JedisDataException.class, e.getClass());
+        }
+    }
+
+    @Test
     void transaction() {
         try {
             val transaction = jedis.multi();


### PR DESCRIPTION
Fixes #73 

For String byte[], it doesn't follow the java serialization protocol, thus a SerializationException will be thrown when deserializing on String byte[]
