### PR TITLE
Close all resources gracefully on JVM shutdown

### DIFF
--- a/core/src/main/java/dev/keva/core/aof/AOFContainer.java
+++ b/core/src/main/java/dev/keva/core/aof/AOFContainer.java
@@ -17,11 +17,13 @@ import java.util.concurrent.locks.ReentrantLock;
 
 @Slf4j
 @Component
-public class AOFContainer {
+public class AOFContainer implements Closeable {
     private ReentrantLock bufferLock;
     private ObjectOutputStream output;
     private FileDescriptor fd;
     private boolean alwaysFlush;
+    private ScheduledExecutorService executorService;
+    private volatile boolean isOpen;
 
     @Autowired
     private KevaConfig kevaConfig;
@@ -48,7 +50,7 @@ public class AOFContainer {
         }
 
         if (!alwaysFlush) {
-            ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+            executorService = Executors.newSingleThreadScheduledExecutor();
             executorService.scheduleAtFixedRate(() -> {
                 try {
                     flush();
@@ -60,10 +62,15 @@ public class AOFContainer {
         } else {
             log.info("AOF will trigger for every new mutate command");
         }
+        isOpen = true;
     }
 
     public void write(Command command) {
         bufferLock.lock();
+        if (!isOpen) {
+            log.warn("Dropping write to AOF as it is closed!");
+            return;
+        }
         try {
             output.writeObject(command.getObjects());
             if (alwaysFlush) {
@@ -74,10 +81,6 @@ public class AOFContainer {
         } finally {
             bufferLock.unlock();
         }
-    }
-
-    private void flush() throws IOException {
-        fd.sync();
     }
 
     public List<Command> read() throws IOException {
@@ -96,6 +99,26 @@ public class AOFContainer {
             log.error(msg, e);
             throw new StartupException(msg, e);
         }
+    }
+
+    public void close() throws IOException {
+        bufferLock.lock();
+        isOpen = false;
+        log.info("Closing AOF log.");
+        try {
+            if (executorService != null) {
+                executorService.shutdown();
+            }
+            // Closing the stream should flush it, but still doing it explicitly!
+            flush();
+            output.close();
+        } finally {
+            bufferLock.unlock();
+        }
+    }
+
+    private void flush() throws IOException {
+        fd.sync();
     }
 
     private String getWorkingDir() {

--- a/core/src/main/java/dev/keva/core/aof/AOFManager.java
+++ b/core/src/main/java/dev/keva/core/aof/AOFManager.java
@@ -50,4 +50,8 @@ public class AOFManager {
 
         aof.init();
     }
+
+    public void stop() throws IOException {
+        aof.close();
+    }
 }

--- a/core/src/main/java/dev/keva/core/exception/StartupException.java
+++ b/core/src/main/java/dev/keva/core/exception/StartupException.java
@@ -1,0 +1,11 @@
+package dev.keva.core.exception;
+
+/**
+ * StartupException indicates any fatal error encountered during server boot.
+ */
+public class StartupException extends RuntimeException{
+
+    public StartupException(final String msg, final Throwable cause){
+        super(msg, cause);
+    }
+}

--- a/core/src/test/java/dev/keva/core/server/AbstractServerTest.java
+++ b/core/src/test/java/dev/keva/core/server/AbstractServerTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class AbstractServerTest {
     static Jedis jedis;
-    static Server server;
+    static volatile Server server;
     static Jedis subscriber;
 
     @Test

--- a/store/src/main/java/dev/keva/store/KevaDatabase.java
+++ b/store/src/main/java/dev/keva/store/KevaDatabase.java
@@ -2,13 +2,17 @@ package dev.keva.store;
 
 import dev.keva.util.hashbytes.BytesKey;
 
+import java.io.Closeable;
 import java.util.AbstractMap;
 import java.util.concurrent.locks.Lock;
 
-public interface KevaDatabase {
+public interface KevaDatabase extends Closeable {
     Lock getLock();
 
     void flush();
+
+    @Override
+    default void close() {}
 
     void put(byte[] key, byte[] val);
 

--- a/store/src/main/java/dev/keva/store/impl/OffHeapDatabaseImpl.java
+++ b/store/src/main/java/dev/keva/store/impl/OffHeapDatabaseImpl.java
@@ -74,6 +74,16 @@ public class OffHeapDatabaseImpl implements KevaDatabase {
         }
     }
 
+    @Override
+    public void close() {
+        lock.lock();
+        try {
+            chronicleMap.close();
+        } finally {
+            lock.unlock();
+        }
+    }
+
     private byte[] getExpireKey(byte[] key) {
         return Bytes.concat(key, EXP_POSTFIX);
     }


### PR DESCRIPTION
This change closes all resources(store, aof) on JVM shutdown.
It also introduces a notion of state in server and adds check on API methods to prevent misuse/race conditions.