### PR TITLE
Fix unit tests failed - failed to create socket consistently

### DIFF
--- a/app/src/test/java/dev/keva/app/ApplicationTest.java
+++ b/app/src/test/java/dev/keva/app/ApplicationTest.java
@@ -16,7 +16,7 @@ class ApplicationTest {
     @Test
     void testMain() throws Exception {
         new Thread(() -> Application.main(ARGS)).start();
-        TimeUnit.SECONDS.sleep(5);
+        TimeUnit.SECONDS.sleep(20);
 
         val jedis = new Jedis("localhost", 6379);
         val pong = jedis.ping();

--- a/core/src/test/java/dev/keva/core/server/AOFTest.java
+++ b/core/src/test/java/dev/keva/core/server/AOFTest.java
@@ -42,7 +42,7 @@ public class AOFTest {
         }).start();
 
         // Wait for server to start
-        TimeUnit.SECONDS.sleep(2);
+        TimeUnit.SECONDS.sleep(10);
         return server;
     }
 
@@ -75,7 +75,7 @@ public class AOFTest {
         }
         jedis.disconnect();
         // Wait for the interval to run
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(10);
         try {
             stop(server);
         } catch (Exception e) {

--- a/core/src/test/java/dev/keva/core/server/KevaServerTest.java
+++ b/core/src/test/java/dev/keva/core/server/KevaServerTest.java
@@ -37,7 +37,7 @@ public class KevaServerTest extends AbstractServerTest {
         }).start();
 
         // Wait for server to start
-        TimeUnit.SECONDS.sleep(2);
+        TimeUnit.SECONDS.sleep(10);
 
         jedis = new Jedis(host, port);
         jedis.auth("keva-auth");

--- a/core/src/test/java/dev/keva/core/server/PersistenceTest.java
+++ b/core/src/test/java/dev/keva/core/server/PersistenceTest.java
@@ -36,7 +36,7 @@ public class PersistenceTest {
         }).start();
 
         // Wait for server to start
-        TimeUnit.SECONDS.sleep(2);
+        TimeUnit.SECONDS.sleep(10);
         return server;
     }
 


### PR DESCRIPTION
Fix #122 Increase timeout for sever to successfully run before running actual tests.
